### PR TITLE
Simple unification and Partial Maps added to ClojureScript's core.logic

### DIFF
--- a/src/main/clojure/cljs/core/logic.cljs
+++ b/src/main/clojure/cljs/core/logic.cljs
@@ -943,8 +943,8 @@
 (defn unify [s u v]
   (if (identical? u v)
     s
-    (let [u (walk s u)
-          v (walk s v)]
+    (let [u (-walk s u)
+          v (-walk s v)]
       (if (identical? u v)
         s
         (-unify-terms u v s)))))


### PR DESCRIPTION
With the changes in this pull request I can correctly replicate the work of Martin's [Datomic-like queries](http://martinsprogrammingblog.blogspot.com/2012/07/replicating-datomicdatalog-queries-with.html) and the examples of partial-map found on StackOverlow, the comments, and hints Kevin told me directly.

One oddity is:

``` clojure
(m/run* [q]
  (m/fresh [pm x]
    (m/== pm (partial-map {:a x}))
    (m/== pm {:a 1 :b 2})
    (m/== x q))))
=> (1)
```

But,

``` clojure
(m/run* [q]
  (m/fresh [pm x]
    (m/== pm (partial-map {:a x}))
    (m/== pm {:a 1 :b 2})
    (m/== pm q))))
=> (#PMap{:a <lvar:x_3>})
```

However, the docs indication is that x should unify and we should see: `{:a 1}` returned

Thoughts?
