### PR TITLE
Make partial-map apply to nested maps

### DIFF
--- a/src/main/clojure/clojure/core/logic.clj
+++ b/src/main/clojure/clojure/core/logic.clj
@@ -3784,15 +3784,7 @@
 (defprotocol IUnifyWithPMap
   (unify-with-pmap [pmap u s]))
 
-(defn unify-with-pmap* [u v s]
-  (loop [ks (keys u) s s]
-    (if (seq ks)
-      (let [kf (first ks)
-            vf (get v kf ::not-found)]
-        (if-let [s (unify s (get u kf) vf)]
-          (recur (next ks) s)
-          nil))
-      s)))
+(declare unify-with-pmap*)
 
 (defrecord PMap []
   IUnifyWithMap
@@ -3817,6 +3809,18 @@
   IWalkTerm
   (walk-term [v f]
     (walk-record-term v f)))
+
+(defn unify-with-pmap* [u v s]
+  (loop [ks (keys u) s s]
+    (if (seq ks)
+      (let [kf (first ks)
+            vf (get v kf ::not-found)]
+        (if-let [s (if (map? vf)
+                     (unify-with-pmap* (get u kf) (map->PMap vf) s)
+                     (unify s (get u kf) vf))]
+          (recur (next ks) s)
+          nil))
+      s)))
 
 (extend-protocol IUnifyWithPMap
   nil

--- a/src/test/clojure/clojure/core/logic/tests.clj
+++ b/src/test/clojure/clojure/core/logic/tests.clj
@@ -1248,6 +1248,14 @@
              (== {:a 1 :b 2} pm)
              (== q pm))))))
 
+(deftest test-nested-partial-map-unification
+  (is (= '[#clojure.core.logic.PMap{:a {:b 2}}]
+         (run* [q]
+           (fresh [pm x]
+             (== (partial-map {:a {:b x}}) pm)
+             (== {:a {:b 2 :c 3}} pm)
+             (== q pm))))))
+
 ;; =============================================================================
 ;; cKanren
 


### PR DESCRIPTION
When unifying with a partial-map, apply partial map unification to nested maps.
