### PR TITLE
fix missing arg in rembero docstring

### DIFF
--- a/src/main/clojure/clojure/core/logic.clj
+++ b/src/main/clojure/clojure/core/logic.clj
@@ -2407,7 +2407,7 @@
      (distincto (lcons h1 t))))
 
 (defne rembero
-  "A relation between l and o where is removed from
+  "A relation between l and o where x is removed from
    l exactly one time."
   [x l o]
   ([_ [x . xs] xs])


### PR DESCRIPTION
Hopefully I got that right. I'm trying to understand rembero, and `x` was the one arg not mentioned in the docstring.
