### PR TITLE
Fixed typo in doc string

### DIFF
--- a/src/main/clojure/clojure/core/logic.clj
+++ b/src/main/clojure/clojure/core/logic.clj
@@ -1271,7 +1271,7 @@
   ([& goals] `(fn [a#] (bind* a# ~@goals))))
 
 (defn and*
-  "A function version of all, which takes a list of goals and succeeds only fi they all succeed."
+  "A function version of all, which takes a list of goals and succeeds only if they all succeed."
   [goals]
   (fn [a]
     (reduce bind a goals)))


### PR DESCRIPTION
and*'s doc said "succeeds only fi they all succeed", changed to "succeeds only if they all succeed"