### PR TITLE
Fix link to reference paper about alphaKanren

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Byrd's dissertation
 [Relational Programming in miniKanren: Techniques, Applications, and Implementations](https://pqdtopen.proquest.com/#abstract?dispub=3380156)
 as well as the extensions described in
 [cKanren](http://www.schemeworkshop.org/2011/papers/Alvis2011.pdf) and
-[αKanren](http://www.cs.indiana.edu/~webyrd/alphamk/alphamk.pdf). It
+[αKanren](http://webyrd.net/alphamk/alphamk.pdf). It
 is designed to be easily extended to forms of logic programming beyond
 the ones provided.
 


### PR DESCRIPTION
It seems that the University of Indiana now redirects anything to the author's original website on the school's website to his personal website. As such, this link is broken now, so this updates it to point at the reference paper available from the author's website.