### PR TITLE
Fixing doc for appendo

### DIFF
--- a/src/main/clojure/clojure/core/logic.clj
+++ b/src/main/clojure/clojure/core/logic.clj
@@ -1779,7 +1779,7 @@
 
 (defne appendo
   "A relation where x, y, and z are proper collections,
-  such that z is x appended to y"
+  such that z is y appended to x"
   [x y z]
   ([() _ y])
   ([[a . d] _ [a . r]] (appendo d y r)))


### PR DESCRIPTION
(run* [q] (appendo (list 1 2) (list 3 4) q))
gives ((1 2 3 4))
So it's appending arg 2 (y) to arg 1 (x), not vice versa