### PR TITLE
Remove duplicate def not-found

### DIFF
--- a/src/main/clojure/cljs/core/logic.cljs
+++ b/src/main/clojure/cljs/core/logic.cljs
@@ -480,8 +480,6 @@
 ;; -----------------------------------------------------------------------------
 ;; Unify IPersistentMap with X
 
-(def not-found (js-obj))
-
 (defn unify-with-map* [v u s]
   (if-not (cljs.core/== (count v) (count u))
     (fail s)


### PR DESCRIPTION
Already defined above. Remove the duplicate definition.
Note. there was a previous PR for this, #23

Hi! Thanks for your interest in contributing to this project.

Clojure contrib projects do not use GitHub issues or pull requests, and
require a signed Contributor Agreement. If you would like to contribute,
please read more about the CA and sign that first (this can be done online).

Then go to this project's issue tracker in JIRA to create tickets, update
tickets, or submit patches. For help in creating tickets and patches,
please see:

- Signing the CA: https://clojure.org/community/contributing
- Creating Tickets: https://clojure.org/community/creating_tickets
- Developing Patches: https://clojure.org/community/developing_patches
- Contributing FAQ: https://clojure.org/community/contributing
