### PR TITLE
Remove warning - refer Clojure without indexed?

### DIFF
--- a/src/main/clojure/cljs/core/logic/pldb.clj
+++ b/src/main/clojure/cljs/core/logic/pldb.clj
@@ -6,7 +6,8 @@
 ;   the terms of this license.
 ;   You must not remove this notice, or any other, from this software.
 
-(ns cljs.core.logic.pldb)
+(ns cljs.core.logic.pldb
+  (:refer-clojure :exclude [indexed?]))
 
 (defn indexed? [v]
   (true? (:index (meta v))))


### PR DESCRIPTION
Remove this warning:

    WARNING: indexed? already refers to: #'clojure.core/indexed? in namespace: cljs.core.logic.pldb, being replaced by: #'cljs.core.logic.pldb/indexed?

Hi! Thanks for your interest in contributing to this project.

Clojure contrib projects do not use GitHub issues or pull requests, and
require a signed Contributor Agreement. If you would like to contribute,
please read more about the CA and sign that first (this can be done online).

Then go to this project's issue tracker in JIRA to create tickets, update
tickets, or submit patches. For help in creating tickets and patches,
please see:

- Signing the CA: https://clojure.org/community/contributing
- Creating Tickets: https://clojure.org/community/creating_tickets
- Developing Patches: https://clojure.org/community/developing_patches
- Contributing FAQ: https://clojure.org/community/contributing
